### PR TITLE
Fix assets being creating in .gitplan/repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.gitplan

--- a/consume.go
+++ b/consume.go
@@ -157,8 +157,8 @@ func processFile(repository *git.Repository, filename string) {
 	// I'm done wasting time looking for information about go-git
 	os.Chdir(".gitplan/repo")
 	defer os.Chdir("../..")
-	cmd = exec.Command("git", "push")
-	_, err = cmd.Output()
+	//cmd = exec.Command("git", "push")
+	//_, err = cmd.Output()
 	if err != nil {
 		Notify(fmt.Sprintf("Something went wrong pushing your changes: %v", err.Error()), false)
 		return

--- a/consume.go
+++ b/consume.go
@@ -156,9 +156,10 @@ func processFile(repository *git.Repository, filename string) {
 	// pushing with go-git seems boring and is not equal to "git push"
 	// I'm done wasting time looking for information about go-git
 	os.Chdir(".gitplan/repo")
-	defer os.Chdir("../..")
+
 	//cmd = exec.Command("git", "push")
 	//_, err = cmd.Output()
+	os.Chdir("../..")
 	if err != nil {
 		Notify(fmt.Sprintf("Something went wrong pushing your changes: %v", err.Error()), false)
 		return

--- a/consume.go
+++ b/consume.go
@@ -157,8 +157,8 @@ func processFile(repository *git.Repository, filename string) {
 	// I'm done wasting time looking for information about go-git
 	os.Chdir(".gitplan/repo")
 
-	//cmd = exec.Command("git", "push")
-	//_, err = cmd.Output()
+	cmd = exec.Command("git", "push")
+	_, err = cmd.Output()
 	os.Chdir("../..")
 	if err != nil {
 		Notify(fmt.Sprintf("Something went wrong pushing your changes: %v", err.Error()), false)


### PR DESCRIPTION
On the first commit using `gitplan consume` assets were created in .gitplan/repo/.gitplan/assets
The second commit would then apply its diff + "git add *" which meant .gitplan/assets were actually committed and pushed.
Fixed that.
Also removed .gitignore to identify such behaviour faster